### PR TITLE
Removed eager loading meta

### DIFF
--- a/src/LaraPress/Posts/Post.php
+++ b/src/LaraPress/Posts/Post.php
@@ -11,8 +11,6 @@ class Post extends Eloquent
 
     protected $primaryKey = 'ID';
 
-    protected $with = ['meta'];
-
     protected $dates = ['post_modified', 'post_modified_gmt', 'post_date', 'post_date_gmt'];
 
     protected $guarded = [''];


### PR DESCRIPTION
WordPress can deliver back a huge dataset of meta...eager load when necessary