### PR TITLE
Add scope for meta querying.

### DIFF
--- a/src/LaraPress/Posts/Post.php
+++ b/src/LaraPress/Posts/Post.php
@@ -71,7 +71,7 @@ class Post extends Eloquent
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function terms()
     {

--- a/src/LaraPress/Posts/Post.php
+++ b/src/LaraPress/Posts/Post.php
@@ -320,4 +320,24 @@ class Post extends Eloquent
     {
         return get_page_template_slug($this->ID);
     }
+    
+    public function scopeWhereMeta(Builder $query, $key, $value = null)
+    {
+        return $query->whereHas('meta', $this->getMetaCallback($key, $value));
+    }
+
+    public function scopeOrWhereMeta(Builder $query, $key, $value = null)
+    {
+        return $query->orWhereHas('meta', $this->getMetaCallback($key, $value));
+    }
+
+    private function getMetaCallback($key, $value = null)
+    {
+        return function (Builder $query) use ($key, $value) {
+            $query->where('meta_key', $key);
+            if ($value) {
+                $query->where('meta_value', $value);
+            }
+        };
+    }
 }

--- a/src/LaraPress/Posts/Post.php
+++ b/src/LaraPress/Posts/Post.php
@@ -340,4 +340,26 @@ class Post extends Eloquent
             }
         };
     }
+
+    public function scopeWhereTerm(Builder $query, $slug, $taxonomy = null)
+    {
+        return $query->whereHas('terms', $this->getTermCallback($slug, $taxonomy));
+    }
+
+    public function scopeOrWhereTerm(Builder $query, $slug, $taxonomy = null)
+    {
+        return $query->whereHas('terms', $this->getTermCallback($slug, $taxonomy));
+    }
+
+    private function getTermCallback($slug, $taxonomy = null)
+    {
+        return function (Builder $query) use ($slug, $taxonomy) {
+            $query->where('slug', $slug);
+            if ($taxonomy) {
+                $query->whereHas('taxonomies', function (Builder $query) use ($taxonomy) {
+                    $query->where('taxonomy', $taxonomy);
+                });
+            }
+        };
+    }
 }

--- a/src/LaraPress/Posts/Post.php
+++ b/src/LaraPress/Posts/Post.php
@@ -320,23 +320,23 @@ class Post extends Eloquent
     {
         return get_page_template_slug($this->ID);
     }
-    
-    public function scopeWhereMeta(Builder $query, $key, $value = null)
+
+    public function scopeWhereMeta(Builder $query, $key, $value = null, $operator = '=')
     {
-        return $query->whereHas('meta', $this->getMetaCallback($key, $value));
+        return $query->whereHas('meta', $this->getMetaCallback($key, $value, $operator));
     }
 
-    public function scopeOrWhereMeta(Builder $query, $key, $value = null)
+    public function scopeOrWhereMeta(Builder $query, $key, $value = null, $operator = '=')
     {
-        return $query->orWhereHas('meta', $this->getMetaCallback($key, $value));
+        return $query->orWhereHas('meta', $this->getMetaCallback($key, $value, $operator));
     }
 
-    private function getMetaCallback($key, $value = null)
+    private function getMetaCallback($key, $value = null, $operator = '=')
     {
-        return function (Builder $query) use ($key, $value) {
+        return function (Builder $query) use ($key, $value, $operator) {
             $query->where('meta_key', $key);
             if ($value) {
-                $query->where('meta_value', $value);
+                $query->where('meta_value', $operator, $value);
             }
         };
     }

--- a/src/LaraPress/Posts/Post.php
+++ b/src/LaraPress/Posts/Post.php
@@ -348,7 +348,7 @@ class Post extends Eloquent
 
     public function scopeOrWhereTerm(Builder $query, $slug, $taxonomy = null)
     {
-        return $query->whereHas('terms', $this->getTermCallback($slug, $taxonomy));
+        return $query->orWhereHas('terms', $this->getTermCallback($slug, $taxonomy));
     }
 
     private function getTermCallback($slug, $taxonomy = null)


### PR DESCRIPTION
Allows:
```php
Page::whereMeta('template', 'one-column')->orWhereMeta('template', 'two-column')->get();
Event::whereMeta('state', 'ID')->get();
Course::whereMeta('seats', 33, '<')->get();
```

We can do this too.
```php
Post::whereTerm('family', 'category')->whereTerm('nice', 'post_tag')->get();
Post::whereTerm('dog', 'post_tag')->orWhereTerm('cat', 'post_tag')->get();
```